### PR TITLE
Chassis/Module Updates

### DIFF
--- a/src/main/config/practicechassis/robot.xml
+++ b/src/main/config/practicechassis/robot.xml
@@ -30,8 +30,10 @@
      Chassis
      ====================================================  -->
     <swervechassis   type="SWERVE"
+                     wheelDiameter="4.13"
                      wheelBase="14.0"  
                      track="14.0"
+                     odometryComplianceCoefficient="1.119"
                      maxVelocity="157.48"
                      maxAngularVelocity="1591.2"
                      maxAcceleration="24"
@@ -45,9 +47,7 @@
                       turn_nominal_val="0.0"
                       turn_peak_val="0.9"
                       turn_max_acc="20"
-                      turn_cruise_vel="50"
-                      wheelDiameter="4.13"
->
+                      turn_cruise_vel="50">
             <motor  usage="DRIVE"
                     canId="3"
                     pdpID="3"
@@ -98,8 +98,7 @@
                       turn_nominal_val="0.0"
                       turn_peak_val="0.9"
                       turn_max_acc="10"
-                      turn_cruise_vel="50"
-			 wheelDiameter="4.13">
+                      turn_cruise_vel="50">
             <motor  usage="DRIVE"
                     canId="1"
                     pdpID="1"
@@ -150,8 +149,7 @@
                       turn_nominal_val="0.0"
                       turn_peak_val="0.9"
                       turn_max_acc="10"
-                      turn_cruise_vel="50"
-			 wheelDiameter="4.13">
+                      turn_cruise_vel="50">
             <motor  usage="DRIVE"
                     canId="13"
                     pdpID="13"
@@ -202,8 +200,7 @@
                       turn_nominal_val="0.0"
                       turn_peak_val="0.9"
                       turn_max_acc="10"
-                      turn_cruise_vel="50"
-			 wheelDiameter="4.13">
+                      turn_cruise_vel="50">
             <motor  usage="DRIVE"
                     canId="15"
                     pdpID="15"

--- a/src/main/config/robot.dtd
+++ b/src/main/config/robot.dtd
@@ -71,12 +71,14 @@
 <!ELEMENT swervechassis (swervemodule*) >
 <!ATTLIST swervechassis 
           type              ( SWERVE ) "SWERVE"
-          wheelBase                 CDATA #REQUIRED
-          track                     CDATA #REQUIRED
-          maxVelocity               CDATA #REQUIRED
-          maxAngularVelocity        CDATA #REQUIRED
-          maxAcceleration           CDATA #REQUIRED
-          maxAngularAcceleration    CDATA #REQUIRED
+          wheelDiameter                     CDATA #REQUIRED
+          wheelBase                         CDATA #REQUIRED
+          track                             CDATA #REQUIRED
+          odometryComplianceCoefficient     CDATA "1.0"
+          maxVelocity                       CDATA #REQUIRED
+          maxAngularVelocity                CDATA #REQUIRED
+          maxAcceleration                   CDATA #REQUIRED
+          maxAngularAcceleration            CDATA #REQUIRED
 >
 
 <!ELEMENT swervemodule (motor*, cancoder? ) >
@@ -90,7 +92,6 @@
           turn_peak_val     CDATA "1.0"
           turn_max_acc      CDATA "0.0"
           turn_cruise_vel   CDATA "0.0"
-          wheelDiameter     CDATA #REQUIRED
 >
 
 

--- a/src/main/config/robot.xml
+++ b/src/main/config/robot.xml
@@ -28,8 +28,10 @@
      Chassis
      ====================================================  -->
     <swervechassis   type="SWERVE"
+                     wheelDiameter="4.13"
                      wheelBase="14.0"  
                      track="14.0"
+                     odometryComplianceCoefficient="0.875"
                      maxVelocity="194.4"
                      maxAngularVelocity="1591.2"
                      maxAcceleration="48"
@@ -43,9 +45,7 @@
                       turn_nominal_val="0.0"
                       turn_peak_val="0.9"
                       turn_max_acc="20"
-                      turn_cruise_vel="50"
-                      wheelDiameter="4.13"
->
+                      turn_cruise_vel="50">
             <motor  usage="DRIVE"
                     canId="3"
                     pdpID="3"
@@ -98,8 +98,7 @@
                       turn_nominal_val="0.0"
                       turn_peak_val="0.9"
                       turn_max_acc="10"
-                      turn_cruise_vel="50"
-			 wheelDiameter="4.13">
+                      turn_cruise_vel="50">
             <motor  usage="DRIVE"
                     canId="1"
                     pdpID="1"
@@ -152,8 +151,7 @@
                       turn_nominal_val="0.0"
                       turn_peak_val="0.9"
                       turn_max_acc="10"
-                      turn_cruise_vel="50"
-			 wheelDiameter="4.13">
+                      turn_cruise_vel="50">
             <motor  usage="DRIVE"
                     canId="13"
                     pdpID="13"
@@ -206,8 +204,7 @@
                       turn_nominal_val="0.0"
                       turn_peak_val="0.9"
                       turn_max_acc="10"
-                      turn_cruise_vel="50"
-			 wheelDiameter="4.13">
+                      turn_cruise_vel="50">
             <motor  usage="DRIVE"
                     canId="15"
                     pdpID="15"

--- a/src/main/cpp/subsys/SwerveChassis.h
+++ b/src/main/cpp/subsys/SwerveChassis.h
@@ -47,10 +47,11 @@ class SwerveChassis
     public:
 
         /// @brief Construct a swerve chassis
-        /// @param [in] std::shared_ptr<SwerveModule>     frontleft:          front left swerve module
-        /// @param [in] std::shared_ptr<SwerveModule>     frontright:         front right swerve module
-        /// @param [in] std::shared_ptr<SwerveModule>     backleft:           back left swerve module
-        /// @param [in] std::shared_ptr<SwerveModule>     backright:          back right swerve module
+        /// @param [in] std::shared_ptr<SwerveModule>           frontleft:          front left swerve module
+        /// @param [in] std::shared_ptr<SwerveModule>           frontright:         front right swerve module
+        /// @param [in] std::shared_ptr<SwerveModule>           backleft:           back left swerve module
+        /// @param [in] std::shared_ptr<SwerveModule>           backright:          back right swerve module
+        /// @param [in] units::length::inch_t                   wheelDiameter:      Diameter of the wheel
         /// @param [in] units::length::inch_t                   wheelBase:          distance between the front and rear wheels
         /// @param [in] units::length::inch_t                   track:              distance between the left and right wheels
         /// @param [in] units::velocity::meters_per_second_t    maxSpeed:           maximum linear speed of the chassis 
@@ -62,8 +63,10 @@ class SwerveChassis
 			std::shared_ptr<SwerveModule>                               frontRight,
 			std::shared_ptr<SwerveModule>                               backLeft, 
 			std::shared_ptr<SwerveModule>                               backRight, 
+            units::length::inch_t                                       wheelDiameter,
 			units::length::inch_t                                       wheelBase,
 			units::length::inch_t                                       track,
+            double                                                      odometryComplianceCoefficient,
 			units::velocity::meters_per_second_t                        maxSpeed,
 			units::radians_per_second_t                                 maxAngularSpeed,
 			units::acceleration::meters_per_second_squared_t            maxAcceleration,
@@ -129,6 +132,7 @@ class SwerveChassis
         //static constexpr auto MaxSpeed = 3.0_mps; 
         //static constexpr units::angular_velocity::radians_per_second_t MaxAngularSpeed{wpi::math::pi};
 
+        units::length::inch_t GetWheelDiameter() const {return m_wheelDiameter; }  
         units::length::inch_t GetWheelBase() const {return m_wheelBase; }  
         units::length::inch_t GetTrack() const {return m_track;}
         units::velocity::meters_per_second_t GetMaxSpeed() const {return m_maxSpeed;}
@@ -149,6 +153,7 @@ class SwerveChassis
         void SetPoseEstOption(PoseEstimationMethod opt ) { m_poseOpt = opt; }
         double GetScaleFactor() const {return m_scale;}
         bool IsMoving() const { return m_isMoving;}
+        double GetodometryComplianceCoefficient() const { return m_odometryComplianceCoefficient; }
 
     private:
         frc::ChassisSpeeds GetFieldRelativeSpeeds
@@ -173,8 +178,10 @@ class SwerveChassis
         frc::SwerveModuleState                                      m_blState;
         frc::SwerveModuleState                                      m_brState;
         
+        units::length::inch_t                                       m_wheelDiameter;       
         units::length::inch_t                                       m_wheelBase;       
         units::length::inch_t                                       m_track;
+        double                                                      m_odometryComplianceCoefficient;
         units::velocity::meters_per_second_t                        m_maxSpeed;
         units::radians_per_second_t                                 m_maxAngularSpeed;
         units::acceleration::meters_per_second_squared_t            m_maxAcceleration;

--- a/src/main/cpp/subsys/SwerveChassisFactory.cpp
+++ b/src/main/cpp/subsys/SwerveChassisFactory.cpp
@@ -61,7 +61,6 @@ std::shared_ptr<SwerveModule> SwerveChassisFactory::CreateSwerveModule
     SwerveModule::ModuleID                                      type, 
     const IDragonMotorControllerMap&        				    motorControllers,   // <I> - Motor Controllers
     std::shared_ptr<ctre::phoenix::sensors::CANCoder>		    canCoder,
-    units::length::inch_t                                       wheelDiameter,
     double                                                      turnP,
     double                                                      turnI,
     double                                                      turnD,
@@ -85,7 +84,6 @@ std::shared_ptr<SwerveModule> SwerveChassisFactory::CreateSwerveModule
                                                         driveMotor, 
                                                         turnMotor, 
                                                         canCoder, 
-                                                        wheelDiameter, 
                                                         turnP,
                                                         turnI,
                                                         turnD,
@@ -105,7 +103,6 @@ std::shared_ptr<SwerveModule> SwerveChassisFactory::CreateSwerveModule
                                                         driveMotor, 
                                                         turnMotor, 
                                                         canCoder, 
-                                                        wheelDiameter, 
                                                         turnP,
                                                         turnI,
                                                         turnD,
@@ -126,7 +123,6 @@ std::shared_ptr<SwerveModule> SwerveChassisFactory::CreateSwerveModule
                                                          driveMotor, 
                                                          turnMotor, 
                                                          canCoder, 
-                                                         wheelDiameter, 
                                                          turnP,
                                                          turnI,
                                                          turnD,
@@ -146,7 +142,6 @@ std::shared_ptr<SwerveModule> SwerveChassisFactory::CreateSwerveModule
                                                         driveMotor, 
                                                         turnMotor, 
                                                         canCoder, 
-                                                        wheelDiameter, 
                                                         turnP,
                                                         turnI,
                                                         turnD,
@@ -178,8 +173,10 @@ shared_ptr<SwerveChassis> SwerveChassisFactory::CreateSwerveChassis
     std::shared_ptr<SwerveModule>                               frontRight,
     std::shared_ptr<SwerveModule>                               backLeft, 
     std::shared_ptr<SwerveModule>                               backRight, 
+    units::length::inch_t                                       wheelDiameter,
     units::length::inch_t                                       wheelBase,
     units::length::inch_t                                       track,
+    double                                                      odometryComplianceCoefficient,
     units::velocity::meters_per_second_t                        maxSpeed,
     units::radians_per_second_t                                 maxAngularSpeed,
     units::acceleration::meters_per_second_squared_t            maxAcceleration,
@@ -188,7 +185,18 @@ shared_ptr<SwerveChassis> SwerveChassisFactory::CreateSwerveChassis
 {
     if ( m_chassis.get() == nullptr )
     {
-        m_chassis = make_shared<SwerveChassis>(frontLeft, frontRight, backLeft, backRight, wheelBase, track, maxSpeed, maxAngularSpeed, maxAcceleration, maxAngularAcceleration );
+        m_chassis = make_shared<SwerveChassis>(frontLeft, 
+                                               frontRight, 
+                                               backLeft, 
+                                               backRight, 
+                                               wheelDiameter,
+                                               wheelBase, 
+                                               track, 
+                                               odometryComplianceCoefficient,
+                                               maxSpeed, 
+                                               maxAngularSpeed, 
+                                               maxAcceleration, 
+                                               maxAngularAcceleration);
     }
 
     return m_chassis;

--- a/src/main/cpp/subsys/SwerveChassisFactory.h
+++ b/src/main/cpp/subsys/SwerveChassisFactory.h
@@ -61,7 +61,6 @@ class SwerveChassisFactory
             SwerveModule::ModuleID                            			type,
 			const IDragonMotorControllerMap&        					motorControllers,   // <I> - Motor Controllers
 			std::shared_ptr<ctre::phoenix::sensors::CANCoder>			turnSensor,
-			units::length::inch_t 										wheelDiameter,
 			double                                                      turnP,
 			double                                                      turnI,
 			double                                                      turnD,
@@ -84,8 +83,10 @@ class SwerveChassisFactory
 			std::shared_ptr<SwerveModule>                               frontRight,
 			std::shared_ptr<SwerveModule>                               backLeft, 
 			std::shared_ptr<SwerveModule>                               backRight, 
+			units::length::inch_t 										wheelDiameter,
 			units::length::inch_t                                       wheelBase,
 			units::length::inch_t                                       track,
+			double														odometryComplianceCoefficient,
 			units::velocity::meters_per_second_t                        maxSpeed,
 			units::radians_per_second_t                                 maxAngularSpeed,
 			units::acceleration::meters_per_second_squared_t            maxAcceleration,

--- a/src/main/cpp/subsys/SwerveModule.cpp
+++ b/src/main/cpp/subsys/SwerveModule.cpp
@@ -64,7 +64,6 @@ SwerveModule::SwerveModule
     shared_ptr<IDragonMotorController>                          driveMotor, 
     shared_ptr<IDragonMotorController>                          turnMotor, 
     std::shared_ptr<ctre::phoenix::sensors::CANCoder>		    canCoder,
-    units::length::inch_t                                       wheelDiameter,
     double                                                      turnP,
     double                                                      turnI,
     double                                                      turnD,
@@ -77,7 +76,7 @@ SwerveModule::SwerveModule
     m_driveMotor(driveMotor), 
     m_turnMotor(turnMotor), 
     m_turnSensor(canCoder), 
-    m_wheelDiameter(wheelDiameter),
+    m_wheelDiameter(0.0),
     m_nt(),
     m_activeState(),
     m_currentPose(),
@@ -174,6 +173,7 @@ SwerveModule::SwerveModule
 
 void SwerveModule::Init
 (
+    units::length::inch_t                                       wheelDiameter,
     units::velocity::meters_per_second_t                        maxVelocity,
     units::angular_velocity::radians_per_second_t               maxAngularVelocity,
     units::acceleration::meters_per_second_squared_t            maxAcceleration,
@@ -181,6 +181,7 @@ void SwerveModule::Init
     Translation2d                                               offsetFromCenterOfRobot
 )
 {
+    m_wheelDiameter = wheelDiameter;
     m_maxVelocity = maxVelocity;
     auto driveCData = make_shared<ControlData>( ControlModes::CONTROL_TYPE::VELOCITY_RPS,
                                                 ControlModes::CONTROL_RUN_LOCS::MOTOR_CONTROLLER,

--- a/src/main/cpp/subsys/SwerveModule.h
+++ b/src/main/cpp/subsys/SwerveModule.h
@@ -60,12 +60,10 @@ class SwerveModule
         /// @param [in] shared_ptr<IDragonMotorController>                      driveMotor:     Motor that makes the robot move  
         /// @param [in] shared_ptr<IDragonMotorController>                      turnMotor:      Motor that turns the swerve module 
         /// @param [in] std::shared_ptr<ctre::phoenix::sensors::CANCoder>		canCoder:       Sensor for detecting the angle of the wheel
-        /// @param [in] units::length::inch_t                                   wheelDiameter   Diameter of the wheel
         SwerveModule( ModuleID                                                  type, 
                       std::shared_ptr<IDragonMotorController>                   driveMotor, 
                       std::shared_ptr<IDragonMotorController>                   turningMotor,
                       std::shared_ptr<ctre::phoenix::sensors::CANCoder>		    canCoder, 
-                      units::length::inch_t                                     wheelDiameter,
                       double                                                    turnP,
                       double                                                    turnI,
                       double                                                    turnD,
@@ -78,6 +76,7 @@ class SwerveModule
 
         void Init
         (
+            units::length::inch_t                                       wheelDiameter,
             units::velocity::meters_per_second_t                        maxVelocity,
             units::angular_velocity::radians_per_second_t               maxAngularVelocity,
             units::acceleration::meters_per_second_squared_t            maxAcceleration,

--- a/src/main/cpp/xmlhw/SwerveChassisDefn.cpp
+++ b/src/main/cpp/xmlhw/SwerveChassisDefn.cpp
@@ -64,8 +64,10 @@ shared_ptr<SwerveChassis> SwerveChassisDefn::ParseXML
 {
     shared_ptr<SwerveChassis> chassis;
     // initialize the attributes to the default values
+    units::length::inch_t wheelDiameter(0.0);
     units::length::inch_t wheelBase(0.0);
     units::length::inch_t track(0.0);
+    double                  odometryComplianceCoefficient(1.0);
     units::velocity::meters_per_second_t maxVelocity(0.0);
     units::radians_per_second_t maxAngularSpeed(0.0);
     units::acceleration::meters_per_second_squared_t maxAcceleration(0.0);
@@ -113,6 +115,14 @@ shared_ptr<SwerveChassis> SwerveChassisDefn::ParseXML
         else if (  attrName.compare("maxAngularAcceleration") == 0 )
         {
             maxAngularAcceleration = units::degrees_per_second_t(attr.as_double()) / 1_s;
+        }
+        else if (  attrName.compare("wheelDiameter") == 0 )
+        {
+        	wheelDiameter = units::length::inch_t(attr.as_double());
+        }
+        else if ( attrName.compare("odometryComplianceCoefficient") == 0 )
+        {
+            odometryComplianceCoefficient = attr.as_double();
         }
         else   // log errors
         {
@@ -180,8 +190,10 @@ shared_ptr<SwerveChassis> SwerveChassisDefn::ParseXML
                                                                                         rfront, 
                                                                                         lback, 
                                                                                         rback, 
+                                                                                        wheelDiameter,
                                                                                         wheelBase, 
                                                                                         track, 
+                                                                                        odometryComplianceCoefficient,
                                                                                         maxVelocity, 
                                                                                         maxAngularSpeed, 
                                                                                         maxAcceleration,

--- a/src/main/cpp/xmlhw/SwerveModuleDefn.cpp
+++ b/src/main/cpp/xmlhw/SwerveModuleDefn.cpp
@@ -63,7 +63,6 @@ std::shared_ptr<SwerveModule> SwerveModuleDefn::ParseXML
 
     // initialize the attributes to the default values
     SwerveModule::ModuleID position = SwerveModule::ModuleID::LEFT_FRONT;
-    units::length::inch_t wheelDiameter(0.0);
     double turnP = 0.0;
     double turnI = 0.0;
     double turnD = 0.0;
@@ -138,10 +137,6 @@ std::shared_ptr<SwerveModule> SwerveModuleDefn::ParseXML
         {
         	turnCruiseVel = attr.as_double();
         }
-        else if (  attrName.compare("wheelDiameter") == 0 )
-        {
-        	wheelDiameter = units::length::inch_t(attr.as_double());
-        }
         else   // log errors
         {
             string msg = "unknown attribute ";
@@ -193,7 +188,6 @@ std::shared_ptr<SwerveModule> SwerveModuleDefn::ParseXML
         module = SwerveChassisFactory::GetSwerveChassisFactory()->CreateSwerveModule(position, 
                                                                                      motors, 
                                                                                      turnsensor, 
-                                                                                     wheelDiameter,
                                                                                      turnP,
                                                                                      turnI,
                                                                                      turnD,


### PR DESCRIPTION
1) Moved Wheel Diameter to the swerve chassis from the swerve module
2) Added odometry compliance coefficient to the swerve chassis and used it in the swerve chassis odometry-based calculations with different values for the practice bot and the comp bot